### PR TITLE
Use proper header parsing function from ampphp/http

### DIFF
--- a/src/DefaultSessionIdGenerator.php
+++ b/src/DefaultSessionIdGenerator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session;
 

--- a/src/LocalSessionStorage.php
+++ b/src/LocalSessionStorage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session;
 

--- a/src/RedisSessionStorage.php
+++ b/src/RedisSessionStorage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session;
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -1,4 +1,4 @@
-<?php /** @noinspection PhpUndefinedClassInspection */
+<?php /** @noinspection PhpUndefinedClassInspection */ declare(strict_types=1);
 
 namespace Amp\Http\Server\Session;
 

--- a/src/SessionException.php
+++ b/src/SessionException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session;
 

--- a/src/SessionFactory.php
+++ b/src/SessionFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session;
 

--- a/src/SessionIdGenerator.php
+++ b/src/SessionIdGenerator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session;
 

--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session;
 
@@ -65,7 +65,7 @@ final class SessionMiddleware implements Middleware
 
         $tokens = [];
         foreach ($cacheControl as [$key, $value]) {
-            assert(is_string($key));
+            \assert($key !== null);
             $tokens[] = match (\strtolower($key)) {
                 'public', 'private' => null,
                 default => $value === '' ? $key : $key . '=' . $value,

--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -65,6 +65,7 @@ final class SessionMiddleware implements Middleware
 
         $tokens = [];
         foreach ($cacheControl as [$key, $value]) {
+            assert(is_string($key));
             $tokens[] = match (\strtolower($key)) {
                 'public', 'private' => null,
                 default => $value === '' ? $key : $key . '=' . $value,

--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -61,7 +61,7 @@ final class SessionMiddleware implements Middleware
             $response->setCookie(new ResponseCookie($this->cookieName, $id, $this->cookieAttributes));
         }
 
-        $cacheControl = Http\parseFieldValueComponents($response, 'cache-control') ?? [];
+        $cacheControl = Http\parseMultipleHeaderFields($response, 'cache-control') ?? [];
 
         $tokens = [];
         foreach ($cacheControl as [$key, $value]) {

--- a/src/SessionStorage.php
+++ b/src/SessionStorage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session;
 

--- a/test/LocalSessionStorageTest.php
+++ b/test/LocalSessionStorageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session\Test;
 

--- a/test/RedisSessionStorageTest.php
+++ b/test/RedisSessionStorageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session\Test;
 

--- a/test/SessionStorageTest.php
+++ b/test/SessionStorageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Amp\Http\Server\Session\Test;
 


### PR DESCRIPTION
The recent release of amphp/http v2 changed one of the function names. This patch updates the use of that function to the new name. I also added strict type declarations and added an `\assert()` call into the `SessionMiddleware` to get static analysis and code linting to pass checks.